### PR TITLE
Some corrections on the stats printer and PEP-0008

### DIFF
--- a/tota/actions.py
+++ b/tota/actions.py
@@ -41,7 +41,8 @@ def check_target_position(f):
     def action_with_target_check(thing, world, target_position):
         if not isinstance(target_position, tuple):
             done = False
-            event = "tried to perform an action into a target that isn't a position"
+            event = ("tried to perform an action into a target that isn't a "
+                     "position")
         else:
             done, event = f(thing, world, target_position)
 

--- a/tota/drawers/json_replay.py
+++ b/tota/drawers/json_replay.py
@@ -56,7 +56,8 @@ class JsonReplayDrawer(Drawer):
                     'xp': getattr(thing, 'xp', None),
                     'action': thing.last_action if is_current_action else None,
                     'target': thing.last_target if is_current_action else None,
-                    'action_done': thing.last_action_done if is_current_action else None,
+                    'action_done': (thing.last_action_done
+                                    if is_current_action else None),
                 })
 
             things_data.append(thing_data)

--- a/tota/drawers/terminal.py
+++ b/tota/drawers/terminal.py
@@ -87,7 +87,7 @@ class TerminalDrawer(Drawer):
             )
 
             screen += '\n' + colored(ancient_stats,
-                                     settings.TEAM_COLORS[team]) + ' \b'
+                                     settings.TEAM_COLORS[team]) + ' \b\b'
 
             for tower in sorted(towers, key=lambda x: x.position):
                 tower_template = '{icon} {bar}({life}/{max_life}) Tower'
@@ -100,7 +100,7 @@ class TerminalDrawer(Drawer):
                 )
 
                 screen += '\n' + colored(tower_stats,
-                                         settings.TEAM_COLORS[team]) + ' \b'
+                                         settings.TEAM_COLORS[team]) + ' \b\b'
 
             for hero in sorted(heroes, key=lambda x: x.name):
                 hero_template = ('{icon} {bar}({life}/{max_life}) Hero: '
@@ -119,7 +119,7 @@ class TerminalDrawer(Drawer):
                 )
 
                 screen += '\n' + colored(hero_stats,
-                                         settings.TEAM_COLORS[team]) + ' \b'
+                                         settings.TEAM_COLORS[team]) + ' \b\b'
 
         # print events (of last step) for debugging
         if game.debug:

--- a/tota/drawers/terminal.py
+++ b/tota/drawers/terminal.py
@@ -75,12 +75,13 @@ class TerminalDrawer(Drawer):
 
             ancient = game.ancients[team]
             towers = game.towers[team]
-            heroes = [hero for hero in game.heroes
-                           if hero.team == team]
+            heroes = [hero for hero in game.heroes if hero.team == team]
 
-            ancient_template = '{icon} {bar}({life}/{max_life}) Ancient                              '
+            ancient_template = ('{icon} {bar}({life}/{max_life}) '
+                                'Ancient').ljust(70)
             ancient_stats = ancient_template.format(
-                icon=ancient.ICON_BASIC if self.use_basic_icons else ancient.ICON,
+                icon=(ancient.ICON_BASIC if self.use_basic_icons
+                      else ancient.ICON),
                 bar=make_bar(20, ancient.life, ancient.max_life),
                 life=int(ancient.life) if ancient.alive else 'destroyed!',
                 max_life=int(ancient.max_life),
@@ -89,20 +90,27 @@ class TerminalDrawer(Drawer):
             screen += '\n' + colored(ancient_stats, settings.TEAM_COLORS[team])
 
             for tower in sorted(towers, key=lambda x: x.position):
-                tower_template = '{icon} {bar}({life}/{max_life}) Tower                               '
+                tower_template = ('{icon} {bar}({life}/{max_life}) '
+                                  'Tower').ljust(70)
                 tower_stats = tower_template.format(
-                    icon=tower.ICON_BASIC if self.use_basic_icons else tower.ICON,
+                    icon=(tower.ICON_BASIC if self.use_basic_icons
+                          else tower.ICON),
                     bar=make_bar(20, tower.life, tower.max_life),
                     life=int(tower.life) if tower.alive else 'destroyed!',
                     max_life=int(tower.max_life),
                 )
 
-                screen += '\n' + colored(tower_stats, settings.TEAM_COLORS[team])
+                screen += '\n' + colored(tower_stats,
+                                         settings.TEAM_COLORS[team])
 
             for hero in sorted(heroes, key=lambda x: x.name):
-                hero_template = '{icon} {bar}({life}/{max_life}) Hero: {name}. Lvl {level} {level_bar} ({author})                         '
+                hero_template = (
+                    '{icon} {bar}({life}/{max_life}) '
+                    'Hero: {name}. Lvl {level} {level_bar} ({author})'
+                ).ljust(70)
                 hero_stats = hero_template.format(
-                    icon=hero.ICON_BASIC if self.use_basic_icons else hero.ICON,
+                    icon=(hero.ICON_BASIC if self.use_basic_icons
+                          else hero.ICON),
                     bar=make_bar(20, hero.life, hero.max_life),
                     name=hero.name,
                     life=int(hero.life) if hero.alive else 'dead',
@@ -113,7 +121,8 @@ class TerminalDrawer(Drawer):
                     author=hero.author,
                 )
 
-                screen += '\n' + colored(hero_stats, settings.TEAM_COLORS[team])
+                screen += '\n' + colored(hero_stats,
+                                         settings.TEAM_COLORS[team])
 
         # print events (of last step) for debugging
         if game.debug:
@@ -128,4 +137,3 @@ class TerminalDrawer(Drawer):
 
         GO_TO_TOP = '\033[0;0H'
         print(GO_TO_TOP + screen)
-

--- a/tota/drawers/terminal.py
+++ b/tota/drawers/terminal.py
@@ -86,8 +86,8 @@ class TerminalDrawer(Drawer):
                 max_life=int(ancient.max_life),
             )
 
-            screen += '\n' + colored(ancient_stats.ljust(50),
-                                     settings.TEAM_COLORS[team])
+            screen += '\n' + colored(ancient_stats,
+                                     settings.TEAM_COLORS[team]) + ' '
 
             for tower in sorted(towers, key=lambda x: x.position):
                 tower_template = '{icon} {bar}({life}/{max_life}) Tower'
@@ -99,8 +99,8 @@ class TerminalDrawer(Drawer):
                     max_life=int(tower.max_life),
                 )
 
-                screen += '\n' + colored(tower_stats.ljust(45),
-                                         settings.TEAM_COLORS[team])
+                screen += '\n' + colored(tower_stats,
+                                         settings.TEAM_COLORS[team]) + ' '
 
             for hero in sorted(heroes, key=lambda x: x.name):
                 hero_template = ('{icon} {bar}({life}/{max_life}) Hero: '
@@ -118,8 +118,8 @@ class TerminalDrawer(Drawer):
                     author=hero.author,
                 )
 
-                screen += '\n' + colored(hero_stats.ljust(80),
-                                         settings.TEAM_COLORS[team])
+                screen += '\n' + colored(hero_stats,
+                                         settings.TEAM_COLORS[team]) + ' '
 
         # print events (of last step) for debugging
         if game.debug:

--- a/tota/drawers/terminal.py
+++ b/tota/drawers/terminal.py
@@ -87,7 +87,7 @@ class TerminalDrawer(Drawer):
             )
 
             screen += '\n' + colored(ancient_stats,
-                                     settings.TEAM_COLORS[team]) + ' '
+                                     settings.TEAM_COLORS[team]) + ' \b'
 
             for tower in sorted(towers, key=lambda x: x.position):
                 tower_template = '{icon} {bar}({life}/{max_life}) Tower'
@@ -100,7 +100,7 @@ class TerminalDrawer(Drawer):
                 )
 
                 screen += '\n' + colored(tower_stats,
-                                         settings.TEAM_COLORS[team]) + ' '
+                                         settings.TEAM_COLORS[team]) + ' \b'
 
             for hero in sorted(heroes, key=lambda x: x.name):
                 hero_template = ('{icon} {bar}({life}/{max_life}) Hero: '
@@ -119,7 +119,7 @@ class TerminalDrawer(Drawer):
                 )
 
                 screen += '\n' + colored(hero_stats,
-                                         settings.TEAM_COLORS[team]) + ' '
+                                         settings.TEAM_COLORS[team]) + ' \b'
 
         # print events (of last step) for debugging
         if game.debug:

--- a/tota/drawers/terminal.py
+++ b/tota/drawers/terminal.py
@@ -77,8 +77,7 @@ class TerminalDrawer(Drawer):
             towers = game.towers[team]
             heroes = [hero for hero in game.heroes if hero.team == team]
 
-            ancient_template = ('{icon} {bar}({life}/{max_life}) '
-                                'Ancient').ljust(70)
+            ancient_template = '{icon} {bar}({life}/{max_life}) Ancient'
             ancient_stats = ancient_template.format(
                 icon=(ancient.ICON_BASIC if self.use_basic_icons
                       else ancient.ICON),
@@ -87,11 +86,11 @@ class TerminalDrawer(Drawer):
                 max_life=int(ancient.max_life),
             )
 
-            screen += '\n' + colored(ancient_stats, settings.TEAM_COLORS[team])
+            screen += '\n' + colored(ancient_stats.ljust(50),
+                                     settings.TEAM_COLORS[team])
 
             for tower in sorted(towers, key=lambda x: x.position):
-                tower_template = ('{icon} {bar}({life}/{max_life}) '
-                                  'Tower').ljust(70)
+                tower_template = '{icon} {bar}({life}/{max_life}) Tower'
                 tower_stats = tower_template.format(
                     icon=(tower.ICON_BASIC if self.use_basic_icons
                           else tower.ICON),
@@ -100,14 +99,12 @@ class TerminalDrawer(Drawer):
                     max_life=int(tower.max_life),
                 )
 
-                screen += '\n' + colored(tower_stats,
+                screen += '\n' + colored(tower_stats.ljust(45),
                                          settings.TEAM_COLORS[team])
 
             for hero in sorted(heroes, key=lambda x: x.name):
-                hero_template = (
-                    '{icon} {bar}({life}/{max_life}) '
-                    'Hero: {name}. Lvl {level} {level_bar} ({author})'
-                ).ljust(70)
+                hero_template = ('{icon} {bar}({life}/{max_life}) Hero: '
+                                 '{name}. Lvl {level} {level_bar} ({author})')
                 hero_stats = hero_template.format(
                     icon=(hero.ICON_BASIC if self.use_basic_icons
                           else hero.ICON),
@@ -121,7 +118,7 @@ class TerminalDrawer(Drawer):
                     author=hero.author,
                 )
 
-                screen += '\n' + colored(hero_stats,
+                screen += '\n' + colored(hero_stats.ljust(80),
                                          settings.TEAM_COLORS[team])
 
         # print events (of last step) for debugging
@@ -136,4 +133,4 @@ class TerminalDrawer(Drawer):
             system('clear')
 
         GO_TO_TOP = '\033[0;0H'
-        print(GO_TO_TOP + screen)
+        print(GO_TO_TOP + screen, end='')

--- a/tota/game.py
+++ b/tota/game.py
@@ -167,11 +167,15 @@ class Game:
                     else:
                         action, target_position = act_result
                         if action not in thing.possible_actions:
-                            message = 'returned unknown action {}'.format(action)
+                            message = (
+                                'returned unknown action {}'.format(action)
+                            )
                         else:
                             actions.append((thing, action, target_position))
-                            message = 'wants to {} into {}'.format(action,
-                                                                   target_position)
+                            message = (
+                                'wants to {} into {}'.format(action,
+                                                             target_position)
+                            )
                         self.event(thing, message)
                 except Exception as err:
                     message = 'error with act from {}: {}'.format(thing.name,
@@ -187,7 +191,8 @@ class Game:
         for thing, action, target_position in actions:
             try:
                 action_function = thing.possible_actions[action]
-                done, event = action_function(thing, self.world, target_position)
+                done, event = action_function(thing, self.world,
+                                              target_position)
                 if done:
                     thing.last_uses[action] = self.world.t
                 thing.last_action_done = done
@@ -215,7 +220,9 @@ class Game:
         for thing in list(self.world.things.values()):
             if not thing.alive:
                 for hero in self.heroes:
-                    if hero.alive and hero.team != thing.team and distance(hero, thing) < settings.XP_DISTANCE:
+                    if (hero.alive
+                            and hero.team != thing.team
+                            and distance(hero, thing) < settings.XP_DISTANCE):
                         xp_gain = 0
                         if isinstance(thing, Creep):
                             xp_gain = settings.XP_CREEP_DEAD
@@ -234,7 +241,8 @@ class Game:
                 self.world.destroy(thing)
                 self.event(thing, 'died')
                 if isinstance(thing, Hero):
-                    thing.respawn_at = self.world.t + settings.HERO_RESPAWN_COOLDOWN
+                    thing.respawn_at = (self.world.t
+                                        + settings.HERO_RESPAWN_COOLDOWN)
                 if isinstance(thing, (Hero, Tower)):
                     enemy_team = settings.ENEMY_TEAMS[thing.team]
                     self.scores[enemy_team] += 1

--- a/tota/play.py
+++ b/tota/play.py
@@ -3,7 +3,8 @@
 
 Usage:
     ./play.py --help
-    ./play.py RADIANT_HEROES DIRE_HEROES [-m MAP] [-s SIZE] [-d] [-b] [-f MAX_FRAMES] [-c] [-r REPLAY_DIR] [-q] [-p]
+    ./play.py RADIANT_HEROES DIRE_HEROES [-m MAP] [-s SIZE] [-d] [-b]
+              [-f MAX_FRAMES] [-c] [-r REPLAY_DIR] [-q] [-p]
 
     DIRE_HEROES and RADIANT_HEROES must be comma separated lists
 

--- a/tota/things.py
+++ b/tota/things.py
@@ -203,7 +203,8 @@ class Hero(Thing):
     @property
     def max_life(self):
         health = settings.HERO_LIFE
-        health_multiplier = 1 + (self.level * settings.HERO_HEALTH_LEVEL_MULTIPLIER)
+        health_multiplier = 1 + (self.level
+                                 * settings.HERO_HEALTH_LEVEL_MULTIPLIER)
 
         return health * health_multiplier
 

--- a/tota/utils.py
+++ b/tota/utils.py
@@ -30,7 +30,8 @@ def sort_by_distance(something, others):
                 random())
 
     sorted_others = list(sorted(others, key=by_distance))
-    if len(sorted_others) > 1 and distance(something, sorted_others[0]) == distance(something, sorted_others[1]):
+    if len(sorted_others) > 1 and (distance(something, sorted_others[0])
+                                   == distance(something, sorted_others[1])):
         x1, y1 = to_position(sorted_others[0])
         x2, y2 = to_position(something)
         delta_x = abs(x1 - x2)
@@ -40,7 +41,8 @@ def sort_by_distance(something, others):
         cut_point = min_value / (max_value + min_value)
 
         if random() < cut_point:
-            sorted_others[0], sorted_others[1] = sorted_others[1], sorted_others[0]
+            sorted_others[0], sorted_others[1] = (sorted_others[1],
+                                                  sorted_others[0])
 
     return sorted_others
 


### PR DESCRIPTION
Made the code PEP-0008 compliant and optimized the stats printer to avoid printing unnecessary white spaces.

![screenshot from 2017-06-02 03-51-44](https://cloud.githubusercontent.com/assets/102958/26714433/c1b41674-4747-11e7-89d3-e81a1645147a.png)

As seen in the selection on the screenshot the lines on stat have no extra selectable spaces after.